### PR TITLE
(수정 필요) 운행 일지 목록 조회, 검색 가능

### DIFF
--- a/src/features/monitoring/DrivingLogPage.tsx
+++ b/src/features/monitoring/DrivingLogPage.tsx
@@ -1,7 +1,178 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { fetchDrivingLogs } from './api/drivinglog-api';
+import { formatLocalDateTime } from '@/utils/date'
+
+import SearchIcon from '@/assets/icons/ic-search.svg?react';
+import {
+  DashboardContainer,
+  FilterContainer,
+  FilterWrap,
+  FilterContent,
+  TableContainer,
+  TableTitle,
+} from '@/components/layout/DashboardLayout.styles';
+import { TextInput } from '@/components/ui/input/input/TextInput';
+import { DateInput } from '@/components/ui/input/date/DateInput';
+import { Dropdown } from '@/components/ui/input/dropdown/Dropdown';
+import { IconButton } from '@/components/ui/button/IconButton';
+import { BasicTable } from '@/components/ui/table/table/BasicTable';
+import { STATUS_OPTIONS, DRIVINGLOG_TABLE_HEADERS } from './types';
+import type { DrivingLogListRequest, DrivingLogSummary, DrivingLogSummaryExtended } from './types';
 
 const DrivingLogPage: React.FC = () => {
-  return <div>운행일지 페이지</div>;
+  const [dateRange, setDateRange] = useState<{ startDate: Date | null; endDate: Date | null }>({
+    startDate: null,
+    endDate: null,
+  });
+
+  const [VehicleRegistrationNumber, setVehicleRegistrationNumber] = useState<string>('');
+  const [userName, setUserName] = useState<string>('');
+  const [status, setStatus] = useState<string>('');
+  //const [drivingLogs, setDrivingLogs] = useState<DrivingLogSummary[]>([]);
+  const [drivingLogs, setDrivingLogs] = useState<DrivingLogSummaryExtended[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
+  const [page, setPage] = useState<number>(0);
+
+  // 운행 일지 목록 가져오기
+  const fetchDrivingLogsData = async () => {
+    try {
+      setIsLoading(true);
+      setError('');
+
+      const params: DrivingLogListRequest = {
+        vehicleNumber: VehicleRegistrationNumber || undefined,
+        userName: userName || undefined,
+        startDate: dateRange.startDate ? dateRange.startDate.toISOString() : undefined,
+        endDate: dateRange.endDate ? dateRange.endDate.toISOString() : undefined,
+        drivingType: status || undefined,
+        page: page,
+        size: 10,
+      };
+
+      const data = await fetchDrivingLogs(params);
+      const parsedData: DrivingLogSummaryExtended[] = data.list.map((item: DrivingLogSummary) => {
+        return {
+          ...item,
+          startAtFormatted: formatLocalDateTime(item.startAt instanceof Date ? item.startAt.toISOString() : item.startAt),
+          endAtFormatted: formatLocalDateTime(item.endAt instanceof Date ? item.endAt.toISOString() : item.endAt),
+          drivingTypeName: parsedDrivingType(item.drivingType)
+        }
+      });
+      setDrivingLogs(parsedData);
+    } catch (err: any) {
+      setError(err.message || '데이터를 가져오는 중 오류 발생');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 검색 버튼 클릭 핸들러
+  const handleSearchClick = () => {
+    fetchDrivingLogsData();
+  };
+
+  // TextInput 변경 핸들러
+  const handleVehicleNumberChange = (value:string) => {
+    setVehicleRegistrationNumber(value);
+    setPage(0);
+  };
+
+  const handleUserNameChange = (value:string) => {
+    setUserName(value);
+    setPage(0);
+  };
+
+  // 상태, 날짜 변경 핸들러
+  const handleDateChange = (value: { startDate: Date | null; endDate: Date | null }) => {
+    setDateRange(value);
+  };
+
+  const handleStatusChange = (value: string | number) => {
+    setStatus(value.toString());  // 항상 string으로 변환
+  };
+
+  // 테이블 row 클릭 핸들러
+  const handleRowClick = (rowData: DrivingLogSummary) => {
+    console.log('선택된 차량:', rowData);
+  };
+
+  const parsedDrivingType = (code: string) => {
+    switch (code) {
+      case 'FOR_BUSINESS_USE':
+        return '업무용';
+      case 'FOR_COMMUTING':
+        return '출퇴근용';
+      default:
+        return '미등록';
+    }
+  }
+
+  // 초기 데이터 로딩
+  useEffect(() => {
+    fetchDrivingLogsData();
+  }, [userName, VehicleRegistrationNumber]);
+
+  return (
+    <DashboardContainer>
+      <FilterContainer>
+        <FilterWrap>
+          <FilterContent>
+            <TextInput
+              width="300px"
+              type="text"
+              id="vehiclenumber-input"
+              label="차량번호"
+              icon={<SearchIcon />}
+              value={VehicleRegistrationNumber}
+              onChange={handleVehicleNumberChange}
+            />
+
+            <TextInput
+              width="300px"
+              type="text"
+              id="username-input"
+              label="사용자"
+              icon={<SearchIcon />}
+              value={userName}
+              onChange={handleUserNameChange}
+            />
+
+            <DateInput
+              id="my-date-input"
+              label="기간 설정"
+              startDate={dateRange.startDate}
+              endDate={dateRange.endDate}
+              onDateChange={handleDateChange}
+              width="320px"
+            />
+
+            <Dropdown
+              width="300px"
+              id="status"
+              label="상태"
+              options={STATUS_OPTIONS}
+              onSelect={handleStatusChange}
+            />
+            
+          </FilterContent>
+          <IconButton icon={<SearchIcon />} >
+            검색
+          </IconButton>
+        </FilterWrap>
+      </FilterContainer>
+
+      <TableContainer>
+        <TableTitle>운행 일지</TableTitle>
+        <BasicTable<DrivingLogSummary>
+          tableHeaders={DRIVINGLOG_TABLE_HEADERS}
+          data={drivingLogs}
+          onRowClick={handleRowClick}
+          message={isLoading ? '로딩 중입니다...' : (error || '데이터가 없습니다.')}
+          ></BasicTable>    
+      </TableContainer>
+    </DashboardContainer>
+  );
 };
 
 export default DrivingLogPage;

--- a/src/features/monitoring/api/drivinglog-api.ts
+++ b/src/features/monitoring/api/drivinglog-api.ts
@@ -1,0 +1,20 @@
+import api from '@/libs/axios';
+import { CODE_SUCCESS, type CommonResponse } from '@/utils/response';
+import type {
+  DrivingLogListRequest,
+  DrivingLogListResponse
+} from '../types';
+
+export const fetchDrivingLogs = async (
+  params: DrivingLogListRequest
+): Promise<DrivingLogListResponse> => {
+  const response = await api.get<CommonResponse<DrivingLogListResponse>>('/api/v1/logs/drive', {
+    params,
+  });
+
+  if (response.data.code !== CODE_SUCCESS) {
+    throw new Error(response.data.message);
+  }
+
+  return response.data.data;
+};

--- a/src/features/monitoring/types.ts
+++ b/src/features/monitoring/types.ts
@@ -1,0 +1,73 @@
+import type { TableHeader } from '@/components/ui/table/table/types';
+import type { DropdownOption } from '@/components/ui/input/dropdown/types';
+
+export interface DrivingLogSummary {
+  id: number;
+  modelName: string;
+  registrationNumber: string;
+  startAt: Date;
+  endAt: Date;
+  startOdometer: number;
+  endOdometer: number;
+  totalDistance: number;
+  user: string;
+  drivingType: string;
+  drivingTypeName: string;
+  memo: string;
+}
+
+export const DRIVINGLOG_TABLE_HEADERS: TableHeader<DrivingLogSummary>[] = [
+  { label: '번호', key: 'id', width: '60px', align: 'center' },
+  { label: '모델', key: 'VehicleModelName', width: '9%', align: 'center' },
+  { label: '차량 번호', key: 'VehicleRegistrationNumber', width: '9%', align: 'center' },
+  { label: '시작 시간', key: 'startAtFormatted', width: '12%', align: 'center' },
+  { label: '종료 시간', key: 'endAtFormatted', width: '12%', align: 'center' },
+  { label: '출발 계기판', key: 'startOdometer', width: '8%', align: 'center' },
+  { label: '도착 계기판', key: 'endOdometer', width: '8%', align: 'center' },
+  { label: '총 주행거리', key: 'totalDistance', width: '8%', align: 'center' },
+  { label: '사용자', key: 'customerName', width: '8%', align: 'center' },
+  {
+    label: '운행 유형',
+    key: 'drivingType',
+    width: '9%',
+    type: 'badge',
+    displayKey: 'drivingTypeName',
+    valueToBadgeColorMap: {
+      FOR_BUSINESS_USE: 'green',
+      FOR_COMMUTING: 'red',
+      NOT_REGISTERED: 'gray',
+    },
+  },
+  { label: '비고', key: 'memo', width: 'auto', align: 'center' },
+];
+
+export const STATUS_OPTIONS: DropdownOption[] = [
+  { value: '', label: '전체' },
+  { value: 'FOR_BUSINESS_USE', label: '업무용' },
+  { value: 'FOR_COMMUTING', label: '출퇴근용' },
+  { value: 'NOT_REGISTERED', label: '미등록' },
+];
+
+export interface DrivingLogListRequest {
+  page?: number;
+  size?: number;
+  vehicleNumber?: string;
+  userName?: string;
+  drivingType?: string;
+  startDate?: string;  // ISO 문자열
+  endDate?: string;
+}
+
+export interface DrivingLogSummaryExtended extends DrivingLogSummary {
+  startAtFormatted: string;
+  endAtFormatted: string;
+  drivingTypeName: string;
+}
+
+export interface DrivingLogListResponse {
+  list: DrivingLogSummary[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

## 📝 작업 내용
운행 일지 목록 조회와 검색 기능만 가능합니다.

## 👀 리뷰어 가이드라인
백엔드에서 운행 유형 enum으로 관리하면서 description도 같이 내려줘야 하는데, 시간이 부족하여 프론트에서 구현해놨습니다 ㅠㅠ
