### PR TITLE
fix: 차량 번호판 유효성 검사 추가(숫자 2~3글자+한글 1글자+숫자 4글자만 통과)

### DIFF
--- a/src/features/vehicle/hooks/useVehicleRegister.ts
+++ b/src/features/vehicle/hooks/useVehicleRegister.ts
@@ -63,6 +63,9 @@ export const useVehicleRegister = (): UseVehicleRegisterReturn => {
     if (!formData.registrationNumber.trim()) {
       newErrors.registrationNumber = '차량 번호를 입력해주세요.';
       isValid = false;
+    } else if (!/^\d{2,3}[가-힣]{1}\d{4}$/.test(formData.registrationNumber)) {
+      newErrors.registrationNumber = '차량 번호 형식이 올바르지 않습니다.';
+      isValid = false;
     }
 
     // 연식 필드의 유효성 검사


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#42 


## 📝 작업 내용
차량을 등록하거나 수정할 때 차량 번호판이 숫자 2~3글자+한글 1글자+숫자 4글자의 구조여야만 통과하도록 정규식을 추가했습니다.