### PR TITLE
fix: 사용자 관리 페이지에서 중복된 이전 페이지 이동 버튼 제거

### DIFF
--- a/src/features/customer/CustomerListPage.tsx
+++ b/src/features/customer/CustomerListPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import api from '@/libs/axios';
 import CustomerCreateModal from './CustomerCreateModal.tsx';
-
 import {
   DashboardContainer,
   TitleContainer,
@@ -346,18 +345,12 @@ const CustomerListPage: React.FC = () => {
         />
         {totalPages > 1 && (
           <PaginationContainer>
-            <PageArrowButton disabled={currentPage === 1} onClick={() => handlePageChange(currentPage - 1)}>
-              {'<'}
-            </PageArrowButton>
             <Pagination
               currentPage={currentPage}
               totalPages={totalPages}
               onPageChange={handlePageChange}
-              pageBlockSize={5}
+              pageBlockSize={10}
             />
-            <PageArrowButton disabled={currentPage === totalPages} onClick={() => handlePageChange(currentPage + 1)}>
-              {'>'}
-            </PageArrowButton>
           </PaginationContainer>
         )}
       </TableContainer>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #59 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

- Pagination 영역에 중복으로 렌더링되던 이전 페이지 이동 버튼(`<PageArrowButton>`) 제거
- Pagination 컴포넌트의 `pageBlockSize` 값을 5 → 10으로 변경하여 한 화면에 더 많은 페이지 번호 표시
- 페이지네이션 영역이 불필요하게 중복되던 문제를 제거하여 사용자 혼란 방지
- UI 정리 및 사용자 경험 향상을 위한 마크업 정리

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->

- 페이지네이션 UI에 버튼이 중복 표시되지 않는지 확인해 주세요
- 페이지 번호가 10개 단위로 잘 렌더링되는지, 페이지 전환 시 동작이 자연스러운지 확인 부탁드립니다
