### PR TITLE
fix: 차량 선택 시 이전 일별 운행 데이터 초기화

### DIFF
--- a/src/features/monitoring/DrivingHistoryPage.tsx
+++ b/src/features/monitoring/DrivingHistoryPage.tsx
@@ -317,6 +317,7 @@ const DrivingHistoryPage: React.FC = () => {
 
   const handleVehicleSelect = async (data: VehicleLog) => {
     setSelectedVehicle(data);
+    setDailyLogData([]);
     const [year, month] = selectedMonth.split('-');
     const from = new Date(Number(year), Number(month) - 1, 1);
     from.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #79 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 운행 통계 조회 -> 차량 -> 주간 그래프 -> 일별 그래프
- 차량 선택 시 이전에 선택된 차량의 일별 운행 기록이 남아 있는 문제를 해결하기 위해 setDailyLogData([]) 추가
- 새로운 차량을 선택할 때 기존 일별 데이터를 초기화하여 화면 정합성 개선
- 주간 그래프 클릭 시 선택된 주차의 일별 데이터를 정확하게 반영하도록 동작 안정성 확보