### PR TITLE
fix: 고객 목록 요청 시 size=1000 제거

### DIFF
--- a/src/features/customer/CustomerListPage.tsx
+++ b/src/features/customer/CustomerListPage.tsx
@@ -177,7 +177,6 @@ const CustomerListPage: React.FC = () => {
     try {
       const response = await api.get('/api/v1/customers', {
         params: {
-          size: 1000,
           sort: 'createdAt,DESC',
           status: filters.status !== '전체' ? statusApiMap[filters.status as keyof typeof statusApiMap] : undefined,
           keyword: filters.keyword || undefined,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #85 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> - 고객 리스트 API 호출 시 불필요한 `size=1000` 파라미터 제거


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

![image](https://github.com/user-attachments/assets/ea8e9ee5-8956-4003-81a3-c2bcb4861aa0)
-> 수정 전

![image](https://github.com/user-attachments/assets/acc01066-1af4-4471-a097-84ce3be5310d)
-> 수정 후